### PR TITLE
Add include_blank option

### DIFF
--- a/fancySelect.coffee
+++ b/fancySelect.coffee
@@ -1,6 +1,7 @@
 $ = window.jQuery || window.Zepto || window.$
 
 $.fn.fancySelect = (opts) ->
+  opts ||= {}
   settings = $.extend({
     forceiOS: false
   }, opts)
@@ -154,6 +155,13 @@ $.fn.fancySelect = (opts) ->
     options.on 'mouseleave', 'li', ->
       options.find('.hover').removeClass('hover')
 
+    find_options_to_be_copied = ->
+      if opts.include_blank
+        sel.find('option')
+      else
+        sel.find('option').filter (el) ->
+          $(sel.find('option')[el]).val() isnt ""
+
     copyOptionsToList = ->
       # update our trigger to reflect the select (it really already should, this is just a safety)
       updateTriggerText()
@@ -164,10 +172,11 @@ $.fn.fancySelect = (opts) ->
       selOpts = sel.find 'option'
 
       # generate list of options for the fancySelect
-      sel.find('option').each (i, opt) ->
+
+      find_options_to_be_copied().each (i, opt) ->
         opt = $(opt)
 
-        if opt.val() && !opt.prop('disabled')
+        if !opt.prop('disabled')
           # Is there a select option on page load?
           if opt.prop('selected')
             options.append "<li data-value=\"#{opt.val()}\" class=\"selected\">#{opt.text()}</li>"

--- a/fancySelect.js
+++ b/fancySelect.js
@@ -6,6 +6,7 @@
 
   $.fn.fancySelect = function(opts) {
     var isiOS, settings;
+    opts || (opts = {});
     settings = $.extend({
       forceiOS: false
     }, opts);
@@ -160,6 +161,15 @@
       options.on('mouseleave', 'li', function() {
         return options.find('.hover').removeClass('hover');
       });
+      find_options_to_be_copied = function() {
+        if (opts.include_blank) {
+          return sel.find('option');
+        } else {
+          return sel.find('option').filter(function(el) {
+            return $(sel.find('option')[el]).val() !== "";
+          });
+        }
+      };
       copyOptionsToList = function() {
         var selOpts;
         updateTriggerText();
@@ -167,9 +177,9 @@
           return;
         }
         selOpts = sel.find('option');
-        return sel.find('option').each(function(i, opt) {
+        return find_options_to_be_copied().each(function(i, opt) {
           opt = $(opt);
-          if (opt.val() && !opt.prop('disabled')) {
+          if (!opt.prop('disabled')) {
             if (opt.prop('selected')) {
               return options.append("<li data-value=\"" + (opt.val()) + "\" class=\"selected\">" + (opt.text()) + "</li>");
             } else {

--- a/index.html
+++ b/index.html
@@ -47,7 +47,7 @@
 		<script src="fancySelect.js"></script>
 		<script>
 			$(document).ready(function() {
-				$('#basic-usage-demo').fancySelect();
+				$('#basic-usage-demo').fancySelect({include_blank: true});
 
 				// Boilerplate
 				var repoName = 'fancyselect'


### PR DESCRIPTION
I was using FancySelect with SimpleForm in my Rails application. I passed to SimpleForm collection_select input :include_blank option and it didn't appear in the option list when I applied FancySelect.
So, I've added an opportunity to keep the blank option in the option list by passing an argument to FancySelect like this:
var mySelect = $('.my-select');
mySelect.fancySelect({include_blank: true});
