### PR TITLE
Fix trigger blur issue

### DIFF
--- a/fancySelect.coffee
+++ b/fancySelect.coffee
@@ -59,6 +59,11 @@ $.fn.fancySelect = (opts) ->
       event.stopPropagation()
 
       unless disabled
+        unless trigger.hasClass 'open'
+          $(".fancy-select").each ->
+            $(this).find('.trigger').removeClass 'open'
+            $(this).find('.options').removeClass 'open'
+
         trigger.toggleClass 'open'
 
         # fancySelect defaults to using native selects with a styled trigger on mobile


### PR DESCRIPTION
When click to an open select element, it could not close. It was about blur method for HTML select element. When you click to an open fancySelect, the blur method was triggered. It has been fixed.
