### PR TITLE
Allow the trigger element to be focusable

### DIFF
--- a/fancySelect.coffee
+++ b/fancySelect.coffee
@@ -109,7 +109,7 @@ $.fn.fancySelect = (opts) ->
       hovered.removeClass('hover')
 
       if !options.hasClass('open')
-        if e.which in [13, 32, 38, 40] # enter, space, up, down
+        if w in [13, 32, 38, 40] # enter, space, up, down
           e.preventDefault()
           trigger.trigger 'click'
       else


### PR DESCRIPTION
This transfers the `tabindex` attribute from the select element to the trigger element, and refactors the key handler to work when the trigger is focused.

Basically this means you can use the tab key to focus the fancy select, and open/close it with the keyboard.
