### PR TITLE
use .attr() to prevent the automatic type conversion

### DIFF
--- a/fancySelect.js
+++ b/fancySelect.js
@@ -156,13 +156,13 @@
       options.on('click', 'li', function(e) {
         var clicked;
         clicked = $(this);
-        sel.val(clicked.data('raw-value'));
+        sel.val(clicked.attr('data-raw-value'));
         if (!isiOS) {
           sel.trigger('blur').trigger('focus');
         }
         options.find('.selected').removeClass('selected');
         clicked.addClass('selected');
-        return sel.val(clicked.data('raw-value')).trigger('change').trigger('blur').trigger('focus');
+        return sel.val(clicked.attr('data-raw-value')).trigger('change').trigger('blur').trigger('focus');
       });
       options.on('mouseenter', 'li', function() {
         var hovered, nowHovered;


### PR DESCRIPTION
When value of select start from starts from a 0 (exemple value="01") the FancySelect don't work.
From the jQuery data() documentation http://api.jquery.com/data/#data2, it appears that you have to use .attr() to prevent the automatic type conversion.

"To retrieve the value's attribute as a string without any attempt to convert it, use the attr() method."
