### PR TITLE
Order of .fancy-select for better validation.

### DIFF
--- a/fancySelect.coffee
+++ b/fancySelect.coffee
@@ -33,10 +33,10 @@ $.fn.fancySelect = (opts = {}) ->
 
     wrapper.addClass(sel.data('class')) if sel.data('class')
 
-    wrapper.append '<div class="trigger">'
-    wrapper.append '<ul class="options">' unless isiOS && !settings.forceiOS
-
+    wrapper.prepend '<div class="trigger">'
     trigger = wrapper.find '.trigger'
+    
+    trigger.after '<ul class="options">' unless isiOS && !settings.forceiOS
     options = wrapper.find '.options'
 
     # disabled in markup?


### PR DESCRIPTION
I've changed the order of the HTML inside .fancy-select as a lot of validation scripts place the validation message after the select element causing strange layouts, so the order is now trigger, options, select.