### PR TITLE
Trigger change event on select element

### DIFF
--- a/fancySelect.coffee
+++ b/fancySelect.coffee
@@ -148,6 +148,7 @@ $.fn.fancySelect = (opts = {}) ->
 
       options.find('.selected').removeClass('selected')
       clicked.addClass 'selected'
+      sel.change()
       return sel.val(clicked.data('raw-value')).trigger('change.fs').trigger('blur.fs').trigger('focus.fs')
 
     # handle mouse selection


### PR DESCRIPTION
.change() is pretty much needed in 95% of projects, and as there is no on change event for fancy select, I triggered it on the select when an option is selected.
