### PR TITLE
Fixing blur event and reordering fancySelect for better interaction with form validation.

### DIFF
--- a/fancySelect.coffee
+++ b/fancySelect.coffee
@@ -33,10 +33,9 @@ $.fn.fancySelect = (opts = {}) ->
 
     wrapper.addClass(sel.data('class')) if sel.data('class')
 
-    wrapper.append '<div class="trigger">'
-    wrapper.append '<ul class="options">' unless isiOS && !settings.forceiOS
-
+    wrapper.prepend '<div class="trigger">'
     trigger = wrapper.find '.trigger'
+    trigger.after '<ul class="options">' unless isiOS && !settings.forceiOS
     options = wrapper.find '.options'
 
     isHovered = false

--- a/fancySelect.coffee
+++ b/fancySelect.coffee
@@ -39,6 +39,12 @@ $.fn.fancySelect = (opts = {}) ->
     trigger = wrapper.find '.trigger'
     options = wrapper.find '.options'
 
+    isHovered = false
+    options.on 'mouseenter', ->
+      isHovered = true
+    options.on 'mouseleave', ->
+      isHovered = false
+
     # disabled in markup?
     disabled = sel.prop('disabled')
     if disabled
@@ -49,10 +55,14 @@ $.fn.fancySelect = (opts = {}) ->
       trigger.html(triggerHtml)
 
     sel.on 'blur.fs', ->
-      if trigger.hasClass 'open'
+      trigger.removeClass 'focus'
+      if trigger.hasClass 'open' && !isHovered
         setTimeout ->
           trigger.trigger 'close.fs'
         , 120
+
+    sel.on 'focus.fs', ->
+      trigger.addClass 'focus'
 
     trigger.on 'close.fs', ->
       trigger.removeClass 'open'

--- a/fancySelect.js
+++ b/fancySelect.js
@@ -48,6 +48,15 @@
       trigger = wrapper.find('.trigger');
       options = wrapper.find('.options');
       disabled = sel.prop('disabled');
+
+      var isHovered = false;
+      options.on('mouseenter', function() {
+        isHovered = true;
+      });
+      options.on('mouseleave', function() {
+        isHovered = false;
+      });
+
       if (disabled) {
         wrapper.addClass('disabled');
       }
@@ -57,11 +66,15 @@
         return trigger.html(triggerHtml);
       };
       sel.on('blur.fs', function() {
-        if (trigger.hasClass('open')) {
+        trigger.removeClass('focus');
+        if (trigger.hasClass('open') && !isHovered) {
           return setTimeout(function() {
             return trigger.trigger('close.fs');
           }, 120);
         }
+      });
+      sel.on('focus.fs', function() {
+        trigger.addClass('focus');
       });
       trigger.on('close.fs', function() {
         trigger.removeClass('open');

--- a/fancySelect.js
+++ b/fancySelect.js
@@ -41,11 +41,11 @@
       if (sel.data('class')) {
         wrapper.addClass(sel.data('class'));
       }
-      wrapper.append('<div class="trigger">');
-      if (!(isiOS && !settings.forceiOS)) {
-        wrapper.append('<ul class="options">');
-      }
+      wrapper.prepend('<div class="trigger">');
       trigger = wrapper.find('.trigger');
+      if (!(isiOS && !settings.forceiOS)) {
+        trigger.after('<ul class="options">');
+      }
       options = wrapper.find('.options');
       disabled = sel.prop('disabled');
 


### PR DESCRIPTION
There was a problem where if when you selected an option, if your click was too long, the option would get selected because the blur event was being fired.

I added an isHovered variable which gets set to true when you are hovered over the options and removed when you mouseout, then in the blur event I set it to only fire if isHovered is false.

I also re-ordered the elements inside fancy select so the select element comes last, this is because if you use a JS validator like parsley.js, the validation message is placed after the select element, in the previous order this would mean the message was show above the fancy select.

Not sure what you guys think of these, but they are now a standard implementation in all my projects