### PR TITLE
Trigger the change event on the select element

### DIFF
--- a/fancySelect.js
+++ b/fancySelect.js
@@ -156,7 +156,7 @@
       options.on('click.fs', 'li', function(e) {
         var clicked;
         clicked = $(this);
-        sel.val(clicked.data('raw-value'));
+        sel.val(clicked.data('raw-value')).change();
         if (!isiOS) {
           sel.trigger('blur.fs').trigger('focus.fs');
         }


### PR DESCRIPTION
It's important to trigger the `change` event on the select to properly notify other scripts of the change.
