### PR TITLE
Namespace before event name

### DIFF
--- a/fancySelect.coffee
+++ b/fancySelect.coffee
@@ -48,17 +48,17 @@ $.fn.fancySelect = (opts = {}) ->
       triggerHtml = settings.triggerTemplate(sel.find(':selected'))
       trigger.html(triggerHtml)
 
-    sel.on 'blur.fs', ->
+    sel.on 'fs.blur', ->
       if trigger.hasClass 'open'
         setTimeout ->
-          trigger.trigger 'close.fs'
+          trigger.trigger 'fs.close'
         , 120
 
-    trigger.on 'close.fs', ->
+    trigger.on 'fs.close', ->
       trigger.removeClass 'open'
       options.removeClass 'open'
 
-    trigger.on 'click.fs', ->
+    trigger.on 'click fs.click', ->
       unless disabled
         trigger.toggleClass 'open'
 
@@ -93,7 +93,7 @@ $.fn.fancySelect = (opts = {}) ->
       wrapper.addClass 'disabled'
       disabled = true
 
-    sel.on 'change.fs', (e) ->
+    sel.on 'fs.change', (e) ->
       if e.originalEvent && e.originalEvent.isTrusted
         # discard firefox-only automatic event when hitting enter, we want to trigger our own
         e.stopPropagation()
@@ -109,7 +109,7 @@ $.fn.fancySelect = (opts = {}) ->
       if !options.hasClass('open')
         if w in [13, 32, 38, 40] # enter, space, up, down
           e.preventDefault()
-          trigger.trigger 'click.fs'
+          trigger.trigger 'fs.click'
       else
         if w == 38 # up
           e.preventDefault()
@@ -125,12 +125,12 @@ $.fn.fancySelect = (opts = {}) ->
             options.find('li:first-child').addClass('hover')
         else if w == 27 # escape
           e.preventDefault()
-          trigger.trigger 'click.fs'
+          trigger.trigger 'fs.click'
         else if w in [13, 32] # enter, space
           e.preventDefault()
-          hovered.trigger 'click.fs'
+          hovered.trigger 'fs.click'
         else if w == 9 # tab
-          if trigger.hasClass 'open' then trigger.trigger 'close.fs'
+          if trigger.hasClass 'open' then trigger.trigger 'fs.close'
 
         newHovered = options.find('.hover')
         if newHovered.length
@@ -139,27 +139,27 @@ $.fn.fancySelect = (opts = {}) ->
 
     # Handle item selection, and
     # Add class selected to selected item
-    options.on 'click.fs', 'li', (e) ->
+    options.on 'click fs.click', 'li', (e) ->
       clicked = $(this)
 
       sel.val(clicked.data('raw-value'))
 
-      sel.trigger('blur.fs').trigger('focus.fs') unless isiOS
+      sel.trigger('fs.blur').trigger('fs.focus') unless isiOS
 
       options.find('.selected').removeClass('selected')
       clicked.addClass 'selected'
       trigger.addClass 'selected'
-      return sel.val(clicked.data('raw-value')).trigger('change.fs').trigger('blur.fs').trigger('focus.fs')
+      return sel.val(clicked.data('raw-value')).trigger('fs.change').trigger('fs.blur').trigger('fs.focus')
 
     # handle mouse selection
-    options.on 'mouseenter.fs', 'li', ->
+    options.on 'mouseenter fs.mouseenter', 'li', ->
       nowHovered = $(this)
       hovered = options.find('.hover')
       hovered.removeClass 'hover'
 
       nowHovered.addClass 'hover'
 
-    options.on 'mouseleave.fs', 'li', ->
+    options.on 'mouseleave fs.mouseleave', 'li', ->
       options.find('.hover').removeClass('hover')
 
     copyOptionsToList = ->
@@ -187,7 +187,7 @@ $.fn.fancySelect = (opts = {}) ->
             options.append "<li data-raw-value=\"#{opt.val()}\">#{optHtml}</li>"
 
     # for updating the list of options after initialization
-    sel.on 'update.fs', ->
+    sel.on 'fs.update', ->
       wrapper.find('.options').empty()
       copyOptionsToList()
 

--- a/fancySelect.js
+++ b/fancySelect.js
@@ -56,18 +56,18 @@
         triggerHtml = settings.triggerTemplate(sel.find(':selected'));
         return trigger.html(triggerHtml);
       };
-      sel.on('blur.fs', function() {
+      sel.on('fs.blur', function() {
         if (trigger.hasClass('open')) {
           return setTimeout(function() {
-            return trigger.trigger('close.fs');
+            return trigger.trigger('fs.close');
           }, 120);
         }
       });
-      trigger.on('close.fs', function() {
+      trigger.on('fs.close', function() {
         trigger.removeClass('open');
         return options.removeClass('open');
       });
-      trigger.on('click.fs', function() {
+      trigger.on('click fs.click', function() {
         var offParent, parent;
         if (!disabled) {
           trigger.toggleClass('open');
@@ -103,7 +103,7 @@
         wrapper.addClass('disabled');
         return disabled = true;
       });
-      sel.on('change.fs', function(e) {
+      sel.on('fs.change', function(e) {
         if (e.originalEvent && e.originalEvent.isTrusted) {
           return e.stopPropagation();
         } else {
@@ -118,7 +118,7 @@
         if (!options.hasClass('open')) {
           if (w === 13 || w === 32 || w === 38 || w === 40) {
             e.preventDefault();
-            return trigger.trigger('click.fs');
+            return trigger.trigger('fs.click');
           }
         } else {
           if (w === 38) {
@@ -137,13 +137,13 @@
             }
           } else if (w === 27) {
             e.preventDefault();
-            trigger.trigger('click.fs');
+            trigger.trigger('fs.click');
           } else if (w === 13 || w === 32) {
             e.preventDefault();
-            hovered.trigger('click.fs');
+            hovered.trigger('fs.click');
           } else if (w === 9) {
             if (trigger.hasClass('open')) {
-              trigger.trigger('close.fs');
+              trigger.trigger('fs.close');
             }
           }
           newHovered = options.find('.hover');
@@ -153,26 +153,26 @@
           }
         }
       });
-      options.on('click.fs', 'li', function(e) {
+      options.on('click fs.click', 'li', function(e) {
         var clicked;
         clicked = $(this);
         sel.val(clicked.data('raw-value'));
         if (!isiOS) {
-          sel.trigger('blur.fs').trigger('focus.fs');
+          sel.trigger('fs.blur').trigger('fs.focus');
         }
         options.find('.selected').removeClass('selected');
         clicked.addClass('selected');
         trigger.addClass('selected');
-        return sel.val(clicked.data('raw-value')).trigger('change.fs').trigger('blur.fs').trigger('focus.fs');
+        return sel.val(clicked.data('raw-value')).trigger('fs.change').trigger('fs.blur').trigger('fs.focus');
       });
-      options.on('mouseenter.fs', 'li', function() {
+      options.on('mouseenter fs.mouseenter', 'li', function() {
         var hovered, nowHovered;
         nowHovered = $(this);
         hovered = options.find('.hover');
         hovered.removeClass('hover');
         return nowHovered.addClass('hover');
       });
-      options.on('mouseleave.fs', 'li', function() {
+      options.on('mouseleave fs.mouseleave', 'li', function() {
         return options.find('.hover').removeClass('hover');
       });
       copyOptionsToList = function() {
@@ -195,7 +195,7 @@
           }
         });
       };
-      sel.on('update.fs', function() {
+      sel.on('fs.update', function() {
         wrapper.find('.options').empty();
         return copyOptionsToList();
       });

--- a/index.html
+++ b/index.html
@@ -47,7 +47,9 @@
 		<script src="fancySelect.js"></script>
 		<script>
 			$(document).ready(function() {
-				$('#basic-usage-demo').fancySelect();
+				$('#basic-usage-demo').fancySelect().on('fs.change', function() {
+					$(this).change();
+				});
 
 				// Boilerplate
 				var repoName = 'fancyselect'


### PR DESCRIPTION
Hey,

Custom event namespaces must come **before** the event's name, otherwise the event gets triggered also when not namespaced.

For example, trying to trigger the `change` event on the `<select>` element from inside the `change.fs` event will trigger `change` as well, causing an infinite triggering of the `change` event.

As an example I modified the `index.html` file to include the triggering of the `change` event on the `<select>` element. If you try it with the current namespacing you'll see the event gets triggered infinitely, eventually causing en error.

Moving the namespace to the front (which is anyway the correct way of namespacing) fixes this issue.

Thanks ;)
