### PR TITLE
Fix scroll Bug

### DIFF
--- a/fancySelect.js
+++ b/fancySelect.js
@@ -57,10 +57,12 @@
         return trigger.html(triggerHtml);
       };
       sel.on('blur.fs', function() {
-        if (trigger.hasClass('open')) {
+        if (trigger.hasClass('open') && !options.is(':hover')) {
           return setTimeout(function() {
             return trigger.trigger('close.fs');
           }, 120);
+        } else {
+          sel.focus();
         }
       });
       trigger.on('close.fs', function() {


### PR DESCRIPTION
A more elegant approach to fixing `Closing when clicking on scroll bar #65`.
  - added condition to if statement in `blur.fs` to detect if options is hovered.
  - if not hovered, keep <select> in focus.