### PR TITLE
add includeBlank option to docs

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -77,6 +77,19 @@ mySelect.trigger('enable.fs'); // now enabled
 mySelect.trigger('disable.fs'); // now disabled again
 ```
 
+
+Including Blank Option
+----------------------
+
+FancySelect can include the blank option in the options list if you pass the `includeBlank` parameter:
+
+### JavaScript
+
+```
+var mySelect = $('.my-select');
+mySelect.fancySelect({includeBlank: true});
+```
+
 Templates
 ---------
 


### PR DESCRIPTION
Hello!
I've just realized that the `includeBlank` option was not documented! Almost 2 years later >_<. I'm not sure if the text has totally correct grammar, so, please take a look!