### PR TITLE
Add support for optgroups

### DIFF
--- a/fancySelect.css
+++ b/fancySelect.css
@@ -144,3 +144,13 @@ div.fancy-select ul.options li.selected {
 div.fancy-select ul.options li.hover {
 	color: #fff;
 }
+
+div.fancy-select ul.options li.optgroup {
+	color: #8e8e8e;
+	cursor: default;
+	font-style: italic;
+}
+
+.fancy-select ul.options li.optchild {
+	padding-left: 30px;
+}

--- a/fancySelect.js
+++ b/fancySelect.js
@@ -156,6 +156,9 @@
       options.on('mousedown.fs', 'li', function(e) {
         var clicked;
         clicked = $(this);
+        if (clicked.hasClass("optgroup")) {
+        	return false;
+        }
         sel.val(clicked.data('raw-value'));
         if (!isiOS) {
           sel.trigger('blur.fs').trigger('focus.fs');
@@ -181,18 +184,24 @@
         if (isiOS && !settings.forceiOS) {
           return;
         }
-        selOpts = sel.find('option');
-        return sel.find('option').each(function(i, opt) {
+        selOpts = sel.find('option, optgroup');
+        return sel.find('option, optgroup').each(function(i, opt) {
           var optHtml;
           opt = $(opt);
-          if (!opt.prop('disabled') && (opt.val() || settings.includeBlank)) {
+          if (opt.is("optgroup")) {
+          	return options.append("<li class=\"optgroup\" data-raw-value=\"\">" + opt.attr("label") + "</li>");
+          }else if (!opt.prop('disabled') && (opt.val() || settings.includeBlank)) {
             optHtml = settings.optionTemplate(opt);
+            var isChild = opt.parent().is("optgroup");
             if (opt.prop('selected')) {
-              return options.append("<li data-raw-value=\"" + (opt.val()) + "\" class=\"selected\">" + optHtml + "</li>");
+              return options.append("<li data-raw-value=\"" + (opt.val()) + "\" class=\"selected" + (isChild ? " optchild" : "") + "\">" + optHtml + "</li>");
             } else {
-              return options.append("<li data-raw-value=\"" + (opt.val()) + "\">" + optHtml + "</li>");
+              return options.append("<li data-raw-value=\"" + (opt.val()) + "\"" + (isChild ? " class=\"optchild\"" : "") + ">" + optHtml + "</li>");
             }
           }
+        });
+        options.find(".optgroup").on("click", function(e){
+        	e.preventDefault();
         });
       };
       sel.on('update.fs', function() {


### PR DESCRIPTION
I appreciate this repo is no longer supported, but for the sake of those still using FancySelect and want to support styling for older browsers, this update allows for optgroups and their labels to be taken into account (previously, they were totally ignored).
All feedback to the PR welcome :-)